### PR TITLE
Fix typo in `initBackrground`

### DIFF
--- a/MemoryManagement/LinkedList/LinkedList/src/main.cpp
+++ b/MemoryManagement/LinkedList/LinkedList/src/main.cpp
@@ -116,7 +116,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/ALittleSpontaneity/src/main.cpp
+++ b/WarmUp/MovingOn/ALittleSpontaneity/src/main.cpp
@@ -60,7 +60,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/ConsumeAnObject/src/main.cpp
+++ b/WarmUp/MovingOn/ConsumeAnObject/src/main.cpp
@@ -58,7 +58,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/DrawALine/src/main.cpp
+++ b/WarmUp/MovingOn/DrawALine/src/main.cpp
@@ -45,7 +45,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/GivingDirection/src/main.cpp
+++ b/WarmUp/MovingOn/GivingDirection/src/main.cpp
@@ -44,7 +44,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/HavingFun/src/main.cpp
+++ b/WarmUp/MovingOn/HavingFun/src/main.cpp
@@ -47,7 +47,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/HuntingBugs/src/main.cpp
+++ b/WarmUp/MovingOn/HuntingBugs/src/main.cpp
@@ -71,7 +71,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/KeepSpinning/src/main.cpp
+++ b/WarmUp/MovingOn/KeepSpinning/src/main.cpp
@@ -62,7 +62,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/LimitsOfPossible/src/main.cpp
+++ b/WarmUp/MovingOn/LimitsOfPossible/src/main.cpp
@@ -62,7 +62,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/LookAround/src/main.cpp
+++ b/WarmUp/MovingOn/LookAround/src/main.cpp
@@ -46,7 +46,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/MoveAnObject/src/main.cpp
+++ b/WarmUp/MovingOn/MoveAnObject/src/main.cpp
@@ -46,7 +46,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/MovingUp/src/main.cpp
+++ b/WarmUp/MovingOn/MovingUp/src/main.cpp
@@ -46,7 +46,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/PlayAround/src/main.cpp
+++ b/WarmUp/MovingOn/PlayAround/src/main.cpp
@@ -71,7 +71,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/RunningInALoop/src/main.cpp
+++ b/WarmUp/MovingOn/RunningInALoop/src/main.cpp
@@ -62,7 +62,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/WarmUp/MovingOn/StartTheGame/src/main.cpp
+++ b/WarmUp/MovingOn/StartTheGame/src/main.cpp
@@ -43,7 +43,7 @@ int main() {
 
     sf::Sprite background;
     sf::Texture backgroundTexture;
-    status = initBackrground(background, backgroundTexture);
+    status = initBackground(background, backgroundTexture);
     if (status != 0) {
         return status;
     }

--- a/include/game.hpp
+++ b/include/game.hpp
@@ -36,7 +36,7 @@ inline int initWindow(sf::RenderWindow& window) {
     return 0;
 }
 
-inline int initBackrground(sf::Sprite& sprite, sf::Texture& texture) {
+inline int initBackground(sf::Sprite& sprite, sf::Texture& texture) {
     if (!texture.loadFromFile("resources/space.png")) {
         return 1;
     }


### PR DESCRIPTION
I didn't find any mention of "initBac**kg**round" so nothing will break after replacing "initBac**krg**round".